### PR TITLE
fix MariaDB 10.4 UNIX_TIMESTAMP(CURTIME(4)) => NULL bug

### DIFF
--- a/gen_ticket64.sql
+++ b/gen_ticket64.sql
@@ -1,19 +1,22 @@
 DELIMITER $$
 CREATE FUNCTION `gen_ticket64`() RETURNS BIGINT(20)
 BEGIN
-	DECLARE epoch BIGINT(20);
+    DECLARE epoch BIGINT(20);
     DECLARE current_ms BIGINT(20);
     DECLARE node INTEGER;
     DECLARE incr BIGINT(20);
+    DECLARE next_id BIGINT(20);
     
     SET node = @@server_id;
-    SET current_ms = round(CURRENT_TIMESTAMP(CURTIME(4)) * 1000);
-    SET epoch = 1459440000000; #//change your epoch
+    SET current_ms = round(UNIX_TIMESTAMP(CURRENT_TIMESTAMP(4)) * 1000);
+    SET epoch = 1600000000000;
     
     REPLACE INTO tb_tickets (stub) VALUES ('a');
-	SELECT LAST_INSERT_ID() INTO incr;
+        SELECT LAST_INSERT_ID() INTO incr;
+
+    SET next_id = (current_ms - epoch) << 22 | (node << 12) | (incr % 4096);
+    UPDATE tb_tickets SET last_id = next_id WHERE id = incr;
     
-    
-RETURN (current_ms - epoch) << 22 | (node << 12) | (incr % 4096);
+RETURN next_id;
 END$$
 DELIMITER ;

--- a/gen_ticket64.sql
+++ b/gen_ticket64.sql
@@ -7,7 +7,7 @@ BEGIN
     DECLARE incr BIGINT(20);
     
     SET node = @@server_id;
-    SET current_ms = round(UNIX_TIMESTAMP(CURTIME(4)) * 1000);
+    SET current_ms = round(CURRENT_TIMESTAMP(CURTIME(4)) * 1000);
     SET epoch = 1459440000000; #//change your epoch
     
     REPLACE INTO tb_tickets (stub) VALUES ('a');

--- a/gen_ticket64.sql
+++ b/gen_ticket64.sql
@@ -6,8 +6,7 @@ BEGIN
     DECLARE node INTEGER;
     DECLARE incr BIGINT(20);
     
-    SET node = 1;
-    SET schema_node = 1;
+    SET node = @@server_id;
     SET current_ms = round(UNIX_TIMESTAMP(CURTIME(4)) * 1000);
     SET epoch = 1459440000000; #//change your epoch
     

--- a/tb_tickets.sql
+++ b/tb_tickets.sql
@@ -1,6 +1,7 @@
 CREATE TABLE `tb_tickets` (
   `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
   `stub` char(1) NOT NULL DEFAULT '',
+  `last_id` bigint(20) unsigned NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`),
   UNIQUE KEY `stub` (`stub`)
 ) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;

--- a/tb_tickets.sql
+++ b/tb_tickets.sql
@@ -3,6 +3,6 @@ CREATE TABLE `tb_tickets` (
   `stub` char(1) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`),
   UNIQUE KEY `stub` (`stub`)
-) AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
+) ENGINE=MyISAM AUTO_INCREMENT=36 DEFAULT CHARSET=utf8;
 
 INSERT INTO `tb_tickets` (`stub`) VALUES ('a');

--- a/tb_tickets.sql
+++ b/tb_tickets.sql
@@ -3,6 +3,6 @@ CREATE TABLE `tb_tickets` (
   `stub` char(1) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`),
   UNIQUE KEY `stub` (`stub`)
-) ENGINE=MyISAM AUTO_INCREMENT=36 DEFAULT CHARSET=utf8;
+) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
 
 INSERT INTO `tb_tickets` (`stub`) VALUES ('a');

--- a/tb_tickets.sql
+++ b/tb_tickets.sql
@@ -3,6 +3,6 @@ CREATE TABLE `tb_tickets` (
   `stub` char(1) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`),
   UNIQUE KEY `stub` (`stub`)
-) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
+) AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
 
 INSERT INTO `tb_tickets` (`stub`) VALUES ('a');


### PR DESCRIPTION
1. fix MariaDB 10.4 UNIX_TIMESTAMP(CURTIME(4)) => NULL bug
1. use ```@@server_id``` instead of ```1```
1. remove unuse ```schema_node``` variable